### PR TITLE
index.html - Fixed Broken Link for "Running on Startup"

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@ docker run --name steamcache-dns -p 53:53/udp -e STEAMCACHE_IP=<span class="pl-s
 <h2>
 <a id="running-on-startup" class="anchor" href="#running-on-startup" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Running on Startup</h2>
 
-<p>Please follow the <a href="https://docs.docker.com/articles/host_integration/">instructions in the Docker documentation</a> to run the container at startup.</p>
+<p>Please follow the <a href="https://docs.docker.com/engine/admin/start-containers-automatically/">instructions in the Docker documentation</a> to run the container at startup.</p>
       </section>
     </div>
 


### PR DESCRIPTION
Broken: https://docs.docker.com/articles/host_integration/
Fixed: https://docs.docker.com/engine/admin/start-containers-automatically/